### PR TITLE
Emphasize rating on listing details

### DIFF
--- a/swipeshare_app/lib/components/listing_detail_card.dart
+++ b/swipeshare_app/lib/components/listing_detail_card.dart
@@ -74,12 +74,19 @@ class ListingDetailCard extends StatelessWidget {
             // Sold by
             Text('Sold by:', style: labelStyle),
             Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Text(listing.sellerName, style: valueStyle),
-                const SizedBox(width: 4),
-                Text(
-                  '(\u2605 ${listing.sellerRating.toStringAsFixed(2)})',
-                  style: valueStyle,
+                Row(
+                  children: [
+                    Icon(Icons.star_rounded, size: 20, color: Theme.of(context).colorScheme.onSurface),
+                    const SizedBox(width: 2),
+                    Text(
+                      listing.sellerRating.toStringAsFixed(2),
+                      style: valueStyle,
+                    ),
+                  ],
                 ),
               ],
             ),


### PR DESCRIPTION
- Moves seller rating out of parentheses next to the name and floats it to the right of the "Sold by" row
- Uses a proper star icon instead of a unicode character

Closes #124