### PR TITLE
Fix: prevent cancelling non-active orders (#122)

### DIFF
--- a/firebase/functions/src/functions/order-transaction.ts
+++ b/firebase/functions/src/functions/order-transaction.ts
@@ -10,7 +10,12 @@ import {
   SystemMessage,
 } from "../types";
 import { newOrderSystemMessageContent } from "../utils/constants";
-import { getListing, getOrderRoomName, getUser } from "../utils/firestore";
+import {
+  getListing,
+  getOrderRoomName,
+  getUser,
+  validateOrderParticipant,
+} from "../utils/firestore";
 import { dateToTimeOfDayString } from "../utils/time";
 
 /**
@@ -225,3 +230,41 @@ export const createOrderFromListing = functions.https.onCall(
     });
   },
 );
+
+export const cancelOrder = functions.https.onCall(async (request) => {
+  if (!request.auth) {
+    throw new HttpsError(
+      "unauthenticated",
+      "User must be authenticated to cancel an order",
+    );
+  }
+
+  const { orderId } = request.data;
+  const callerUid = request.auth.uid;
+
+  if (!orderId) {
+    throw new HttpsError("invalid-argument", "orderId is required");
+  }
+
+  const orderData = await validateOrderParticipant(orderId, callerUid);
+
+  if (orderData.status !== orderStatus.active) {
+    throw new HttpsError(
+      "failed-precondition",
+      "Only active orders can be cancelled.",
+    );
+  }
+
+  const cancelledBy =
+    callerUid === orderData.buyerId ? "buyer" : "seller";
+
+  await admin.firestore().collection("orders").doc(orderId).update({
+    status: orderStatus.cancelled,
+    cancelledBy,
+    cancellationAcknowledged: false,
+  });
+
+  console.log(`Order ${orderId} cancelled by ${cancelledBy} (${callerUid})`);
+
+  return { success: true };
+});

--- a/swipeshare_app/lib/old_components/chat_screen/chat_settings.dart
+++ b/swipeshare_app/lib/old_components/chat_screen/chat_settings.dart
@@ -42,10 +42,11 @@ class ChatSettingsMenu extends StatelessWidget {
           value: SettingsItems.block,
           child: Text('Block This User'),
         ),
-        const PopupMenuItem<SettingsItems>(
-          value: SettingsItems.cancelOrder,
-          child: Text('Cancel Order'),
-        ),
+        if (orderData.status == OrderStatus.active)
+          const PopupMenuItem<SettingsItems>(
+            value: SettingsItems.cancelOrder,
+            child: Text('Cancel Order'),
+          ),
       ],
     );
   }

--- a/swipeshare_app/lib/services/order_service.dart
+++ b/swipeshare_app/lib/services/order_service.dart
@@ -73,11 +73,7 @@ class OrderService {
   }
 
   Future<void> cancelOrder(String orderId, OrderRole cancelledBy) async {
-    await orderCol.doc(orderId).update({
-      'status': OrderStatus.cancelled.name,
-      'cancelledBy': cancelledBy.name,
-      'cancellationAcknowledged': false,
-    });
+    await _functions.httpsCallable('cancelOrder').call({'orderId': orderId});
   }
 
   Future<void> acknowledgeCancellation(String orderId) async {


### PR DESCRIPTION
- Hide "Cancel Order" button in UI when order is not active
- Add `cancelOrder` Cloud Function that validates before allowing cancellation
- Client now calls cloud fucntion instead of writing directly

Closes #122